### PR TITLE
Header names should be suffixed by ": " instead of ":"

### DIFF
--- a/Microsoft.Rest.ClientRuntime.Test/TextRpc/StreamEx.cs
+++ b/Microsoft.Rest.ClientRuntime.Test/TextRpc/StreamEx.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Rest.ClientRuntime.Test.TextRpc
         {
             var count = Encoding.UTF8.GetByteCount(message);
             await writer.WriteAsync(ContentLength);
-            await writer.WriteAsync(":");
+            await writer.WriteAsync(": ");
             await writer.WriteLineAsync(count.ToString());
             await writer.WriteLineAsync();
             await writer.WriteAsync(message);


### PR DESCRIPTION
The test framework protocol documentation states that the schema is inherited from the Language Server Protocol. The header section from [language-server-protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#base-protocol) states the following:

> The header part consists of header fields. Each header field is comprised of a name and a value, separated by ': ' (**a colon and a space**).

This change writes the colon and space as specified by LSP.

Not sure if this will break the Go server or not...