### PR TITLE
Adding HttpResponseMessage as some tests need to verify

### DIFF
--- a/Microsoft.Rest.ClientRuntime.Test/Azure/ServiceClientEx.cs
+++ b/Microsoft.Rest.ClientRuntime.Test/Azure/ServiceClientEx.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Rest.ClientRuntime.Test.Azure
             }
             catch (ErrorException<E> e)
             {
-                throw request.Info.CreateException(new AzureError<E>(e.Message, null, null, e.Error.data));
+                throw request.Info.CreateException(new AzureError<E>(e.Message, 
+                                                                     null,
+                                                                     e.Error.HttpResponse != null ? new HttpResponseMessageWrapper(e.Error.HttpResponse, String.Empty) : null,
+                                                                     e.Error.data));
             }
         }
 

--- a/Microsoft.Rest.ClientRuntime.Test/JsonRpc/Error.cs
+++ b/Microsoft.Rest.ClientRuntime.Test/JsonRpc/Error.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Rest.ClientRuntime.Test.JsonRpc
+﻿using System.Net.Http;
+
+namespace Microsoft.Rest.ClientRuntime.Test.JsonRpc
 {
     public sealed class Error<E>
     {
@@ -7,5 +9,7 @@
         public string message { get; set; }
 
         public E data { get; set; } 
+
+        public HttpResponseMessage HttpResponse { get; set; }
     }
 }


### PR DESCRIPTION
Some tests like Management.Batch need to verify the HttpResponseMessage. For example:
```csharp
 // Verify account was deleted. A GET operation will return a 404 error and result in an exception
try
{
    await this.BatchManagementClient.BatchAccount.GetAsync(resourceGroupName, batchAccountName);
}
catch (CloudException ex)
{
    Assert.Equal(HttpStatusCode.NotFound, ex.Response.StatusCode);
}
```

This change would add a way for the test server to return the ```HttpResponseMessage```. Unfortunately the``` Content ``` property isn't serializable, so test servers should clear that property first. In addition, ```HttpResponseMessageWrapper``` is also not serializable, so ```HttpResponseMessage``` is serialized instead and the wrapper is created on the client side.

Let me know if this sounds like an okay change for the schema and any ideas for improvements. Thanks!